### PR TITLE
add GitHub actions, migrate to v2 buf config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    groups:
+      all:
+        update-types:
+          - "minor"
+          - "patch"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -1,0 +1,21 @@
+name: Buf CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  buf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bufbuild/buf-action@v1
+        with:
+          push: false
+          archive: false
+      - name: check generate
+        run: set -ue; buf generate; git diff --quiet || { echo "run 'buf generate'"; exit 1; }

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,15 +1,16 @@
-version: v1
+version: v2
 managed:
   enabled: true
-  go_package_prefix:
-    default: github.com/tempestdx/protobuf/gen/go
+  override:
+    - file_option: go_package_prefix
+      value: github.com/tempestdx/protobuf/gen/go
 plugins:
-  - plugin: buf.build/protocolbuffers/go
+  - remote: buf.build/protocolbuffers/go
     out: gen/go
     opt: paths=source_relative
-  - plugin: buf.build/connectrpc/go
+  - remote: buf.build/connectrpc/go
     out: gen/go
     opt: paths=source_relative
-  - plugin: buf.build/community/pseudomuto-doc
+  - remote: buf.build/community/pseudomuto-doc
     out: gen/doc
     opt: json,out.json

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,7 +1,14 @@
-version: v1
-breaking:
-  use:
-    - FILE
+version: v2
 lint:
   use:
     - STANDARD
+  except:
+    - FIELD_NOT_REQUIRED
+    - PACKAGE_NO_IMPORT_CYCLE
+  disallow_comment_ignores: true
+breaking:
+  use:
+    - FILE
+  except:
+    - EXTENSION_NO_DELETE
+    - FIELD_SAME_DEFAULT


### PR DESCRIPTION
## Contents
1. Adds `dependabot.yml`
2. Adds `Buf CI` action: https://buf.build/docs/ci-cd/github-actions/
3. Migrate to Buf config v2.